### PR TITLE
Apply responseProfile for players list

### DIFF
--- a/app/js/controllers/playerListCtrl.js
+++ b/app/js/controllers/playerListCtrl.js
@@ -82,6 +82,9 @@ angular.module('KMCModule').controller('PlayerListCtrl',
                 'filter:objectType': 'KalturaUiConfFilter',
                 'filter:creationModeEqual': '2',
                 'ignoreNull': '1',
+				'responseProfile:objectType':'KalturaDetachedResponseProfile',
+				'responseProfile:type':'1',
+				'responseProfile:fields':'id,name,html5Url,createdAt,updatedAt',
                 'page:objectType': 'KalturaFilterPager',
                 'pager:pageIndex': '1',
                 'pager:pageSize': '999',
@@ -92,7 +95,7 @@ angular.module('KMCModule').controller('PlayerListCtrl',
                 $scope.data = data.objects;   // players list
                 $scope.calculateTotalItems(); // calculate the total items including search filters to display in the pager
                 PlayerService.cachePlayers(data.objects); // save players list data to memory cache
-	            requestNotificationChannel.requestEnded('list');
+				requestNotificationChannel.requestEnded('list');
                 setTimeout(function(){
                     $scope.triggerLayoutChange(); // update scroller;
                 },300);
@@ -132,13 +135,13 @@ angular.module('KMCModule').controller('PlayerListCtrl',
             // check if this player should be upgraded (binded to the player's HTML outdated message)
             $scope.checkVersionNeedsUpgrade = function(item) {
                 var html5libVersion = item.html5Url.substr(item.html5Url.indexOf('/v') + 2, 1); // get html5 lib version number from its URL
-                return ((html5libVersion == "1" || item.config === null) ); // need to upgrade if the version is lower than 2 or the player doesn't have a config object
+                return ((html5libVersion == "1") ); // need to upgrade if the version is lower than 2 or the player doesn't have a config object
             };
 
             // check if this player is an old playlist
             $scope.checkOldPlaylistPlayer = function(item) {
                 var html5libVersion = item.html5Url.substr(item.html5Url.indexOf('/v') + 2, 1); // get html5 lib version number from its URL
-                return ((html5libVersion == "1" || item.config === null) && item.tags.indexOf("playlist") !== -1); // this player is an old playlist that is not supported in Universal studio
+                return ((html5libVersion == "1") && item.tags.indexOf("playlist") !== -1); // this player is an old playlist that is not supported in Universal studio
             };
 
             $scope.showSubTitle = true; // show the subtitle text below the title

--- a/app/js/services/services.js
+++ b/app/js/services/services.js
@@ -347,37 +347,18 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 
             },
             'getPlayer': function(id) {
-                var foundInCache = false;
                 var deferred = $q.defer();
-                if (typeof currentPlayer.id != 'undefined') { // find if player obj is already loaded
-                    if (currentPlayer.id == id || id == 'currentEdit') { // this ability to get the player data  we alreayd work on is there for future revert update feature.
-                        currentPlayer.config.plugins = this.preparePluginsDataForRender(currentPlayer.config.plugins); // refilter the data incase it was made dirty
-                        playersService.setCurrentPlayer(currentPlayer); // reEnabled plugins.
+                apiService.setCache(false);
+                var request = {
+                    'service': 'uiConf',
+                    'action': 'get',
+                    'id': id
+                };
+                apiService.doRequest(request).then(function(result) {
+                        playersService.setCurrentPlayer(result);
                         deferred.resolve(currentPlayer);
-                        foundInCache = true;
                     }
-                }
-                if (!foundInCache) {
-                    // find player data by its ID in the list cache
-                    if (typeof playersCache[id] != 'undefined') {
-                        playersService.setCurrentPlayer(playersCache[id]);
-                        deferred.resolve(currentPlayer);
-                        foundInCache = true;
-                    }
-                }
-                if (!foundInCache) {
-                    var request = {
-                        'service': 'uiConf',
-                        'action': 'get',
-                        'id': id
-
-                    };
-                    apiService.doRequest(request).then(function(result) {
-                            playersService.setCurrentPlayer(result);
-                            deferred.resolve(currentPlayer);
-                        }
-                    );
-                }
+                );
                 return deferred.promise;
             },
             setCurrentPlayer: function(player) {


### PR DESCRIPTION
Apply responseProfile for players list to retrieve only required fields from the UIConf and not all the fields. Updated cache mechanism to always load the selected player UIConf from service and not from the cached players list.