### PR TITLE
fix(10019): if remove english and set other language as default, english still displayed

### DIFF
--- a/app/js/controllers/EditCtrl.js
+++ b/app/js/controllers/EditCtrl.js
@@ -414,6 +414,10 @@ KMCMenu.controller('EditCtrl', ['$scope','$http', '$timeout','PlayerData','Playe
 	    }
 	    if (property.model === "playerLangCodes"){
 		    $scope.playerLangCodesChanged = true;
+		    if ($scope.playerData.playerLangCodes.length === 0 && property.initvalue[0] !== 'en') {
+		    	// move from empty (english by default) to non-english
+			    window.KalturaPlayer = null;
+		    }
 		    $scope.playerData.playerLangCodes = property.initvalue || [];
 		    $scope.playerData.playerLang = $.map($scope.playerData.playerLangCodes, function(lang) {
 				return $.grep(property.options, function (langObj) {

--- a/app/js/services/services.js
+++ b/app/js/services/services.js
@@ -388,7 +388,7 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 				};
 
 				var loadScript = function (env) {
-					require('//' + env + '/p/' + partner_id + '/embedPlaykitJs/uiconf_id/' + uiconf_id + '/versions/' + playerVersionParam + getPluginsVersion() + '/langs/' + playerData.playerLangCodes.toString(), callback);
+					require('//' + env + '/p/' + partner_id + '/embedPlaykitJs/uiconf_id/' + uiconf_id + '/versions/' + playerVersionParam + getPluginsVersion() + '/langs/' + (playerData.playerLangCodes.toString() || 'en'), callback);
 				};
 
 				if (window.parent.kmc && window.parent.kmc.vars && window.parent.kmc.vars.host) {


### PR DESCRIPTION
* reset kaltura player when moving from empty (English by default) to non-English
* pass `langs/en` by default