### PR TITLE
fix(10019): if remove english and set other language as default, english still displayed

### DIFF
--- a/app/js/controllers/EditCtrl.js
+++ b/app/js/controllers/EditCtrl.js
@@ -11,7 +11,6 @@ KMCMenu.controller('EditCtrl', ['$scope','$http', '$timeout','PlayerData','Playe
 	$scope.aspectRatio = playerRatio == (9/16) ? "wide" : playerRatio == (3/4) ? "narrow" : "custom";  // set aspect ratio to wide screen
 	$scope.newPlayer = !$routeParams.id;            // New player flag
 	$scope.menuOpen = true;
-	$scope.playerLangCodesChanged = false;
 
 	try {
 		var confVarsObj = JSON.parse($scope.playerData.confVars);
@@ -417,11 +416,6 @@ KMCMenu.controller('EditCtrl', ['$scope','$http', '$timeout','PlayerData','Playe
 		    $scope.playerData.languageKey = property.initvalue;
 	    }
 	    if (property.model === "playerLangCodes"){
-		    $scope.playerLangCodesChanged = true;
-		    if ($scope.playerData.playerLangCodes.length === 0 && property.initvalue[0] !== 'en') {
-				// move from empty (english by default) to non-english
-			    window.KalturaPlayer = null;
-		    }
 		    $scope.playerData.playerLangCodes = property.initvalue || [];
 		    $scope.playerData.playerLang = $.map($scope.playerData.playerLangCodes, function(lang) {
 				return $.grep(property.options, function (langObj) {
@@ -429,9 +423,12 @@ KMCMenu.controller('EditCtrl', ['$scope','$http', '$timeout','PlayerData','Playe
 			    })[0];
 		    });
 	    }
-	    if (property.model === "config.ui.locale" && $scope.playerLangCodesChanged){
-		    $scope.playerLangCodesChanged = false;
-		    window.KalturaPlayer = null;
+	    if (property.model === "config.ui.locale" && !property.initvalue) {
+			if ($scope.playerData.playerLangCodes.length === 0) {
+			    property.initvalue = 'en';
+		    } else {
+			    property.initvalue = $scope.playerData.playerLangCodes[0];
+		    }
 	    }
 
 	    if (property.componentName){ // handle external bundles

--- a/app/js/controllers/EditCtrl.js
+++ b/app/js/controllers/EditCtrl.js
@@ -512,6 +512,26 @@ KMCMenu.controller('EditCtrl', ['$scope','$http', '$timeout','PlayerData','Playe
 	    }
     };
 
+    $scope.getAllLangCodes = function () {
+    	try {
+    		var lookAndFeelCategory = $.grep($scope.menuData, function (category) {
+    			return category.id === 'lookandfeel';
+		    })[0];
+    		var lookAndFeelPlugins = lookAndFeelCategory['plugins'] || lookAndFeelCategory['pluginsNotLoaded'];
+		    var localizationPlugin = $.grep(lookAndFeelPlugins, function (plugin) {
+			    return plugin.label === 'Localization';
+		    })[0];
+		    var languagesComponent = $.grep(localizationPlugin.properties, function (property) {
+			    return property.label === 'Languages';
+		    })[0];
+    		return $.map(languagesComponent.options, function(lang) {
+    			return lang.value;
+		    });
+	    } catch (e) {
+		    return '';
+	    }
+    };
+
 	$scope.renderPlayer = function(){
 		$scope.updatePlayerData(); // update the player data from the menu data
 		$scope.$broadcast('beforeRenderEvent'); // allow other controllers to update the player data if needed
@@ -533,7 +553,7 @@ KMCMenu.controller('EditCtrl', ['$scope','$http', '$timeout','PlayerData','Playe
 		requestNotificationChannel.requestStarted('edit'); // show spinner
 		PlayerService.renderPlayer($scope.playerData, flashvars, entryID, function () {
 			requestNotificationChannel.requestEnded('edit'); // hide spinner
-		}, $scope.entriesTypeSelector === "Playlist");
+		}, $scope.entriesTypeSelector === "Playlist", $scope.getAllLangCodes());
 	};
 
 	// merge the player data with the menu data

--- a/app/js/services/services.js
+++ b/app/js/services/services.js
@@ -225,6 +225,7 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 			KALTURA_PLAYER_OTT: 'kaltura-tv-player',
 			OVP: 'ovp',
 			OTT: 'ott',
+			PLAYER_LANGS: 'en,de,fr,es,it,nl,ru,pt_br,ja,zh_cn,zh_tw,hi_in,ar',
 			playerVersionsMap: null,
 			autoRefreshEnabled: false,
 			clearCurrentRefresh: function () {
@@ -388,7 +389,7 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 				};
 
 				var loadScript = function (env) {
-					require('//' + env + '/p/' + partner_id + '/embedPlaykitJs/uiconf_id/' + uiconf_id + '/versions/' + playerVersionParam + getPluginsVersion() + '/langs/' + (playerData.playerLangCodes.toString() || 'en'), callback);
+					require('//' + env + '/p/' + partner_id + '/embedPlaykitJs/uiconf_id/' + uiconf_id + '/versions/' + playerVersionParam + getPluginsVersion() + '/langs/' + playersService.PLAYER_LANGS, callback);
 				};
 
 				if (window.parent.kmc && window.parent.kmc.vars && window.parent.kmc.vars.host) {

--- a/app/js/services/services.js
+++ b/app/js/services/services.js
@@ -225,7 +225,6 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 			KALTURA_PLAYER_OTT: 'kaltura-tv-player',
 			OVP: 'ovp',
 			OTT: 'ott',
-			PLAYER_LANGS: 'en,de,fr,es,it,nl,ru,pt_br,ja,zh_cn,zh_tw,hi_in,ar',
 			playerVersionsMap: null,
 			autoRefreshEnabled: false,
 			clearCurrentRefresh: function () {
@@ -290,7 +289,7 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 				}
 				return true;
 			},
-			'renderPlayer': function (playerData, playerConfig, entry_id, callback, isPlaylist) {
+			'renderPlayer': function (playerData, playerConfig, entry_id, callback, isPlaylist, allLangCodes) {
 				var partner_id = playerData.partnerId;
 				var forceTouchUI = playerData.forceTouchUI;
 				var loadPlayer = function () {
@@ -341,9 +340,9 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 					} else {
 						callback();
 					}
-				});
+				}, allLangCodes);
 			},
-			'loadKalturaPlayerScript': function (playerData, callback) {
+			'loadKalturaPlayerScript': function (playerData, callback, allLangCodes) {
 				if (window.KalturaPlayer) {
 					callback();
 					return;
@@ -389,7 +388,7 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 				};
 
 				var loadScript = function (env) {
-					require('//' + env + '/p/' + partner_id + '/embedPlaykitJs/uiconf_id/' + uiconf_id + '/versions/' + playerVersionParam + getPluginsVersion() + '/langs/' + playersService.PLAYER_LANGS, callback);
+					require('//' + env + '/p/' + partner_id + '/embedPlaykitJs/uiconf_id/' + uiconf_id + '/versions/' + playerVersionParam + getPluginsVersion() + '/langs/' + allLangCodes, callback);
 				};
 
 				if (window.parent.kmc && window.parent.kmc.vars && window.parent.kmc.vars.host) {

--- a/app/js/services/v3Properties.json
+++ b/app/js/services/v3Properties.json
@@ -208,6 +208,7 @@
           {
             "label": "Languages",
             "helpnote": "Select all languages to be bundled with the player",
+            "player-refresh": false,
             "type": "dropdown",
             "options": [
               {


### PR DESCRIPTION
Reverts #81 
* load all language in advance to avoid reloading kaltura-player in every language addition or selection
* set locale to English when empting the language list
* set locale to the additional language when adding the first one