### PR TITLE
fix(FEC-12074): As a platform user I would like to have automatic display of the related grid when entry playback is over

### DIFF
--- a/app/js/services/v3Properties.json
+++ b/app/js/services/v3Properties.json
@@ -571,13 +571,6 @@
             "initvalue": false
           },
           {
-            "label": "Display when playback is over",
-            "helpnote": "Display related screen when playback ends",
-            "type": "checkbox",
-            "model": "config.plugins.related.showOnPlaybackDone",
-            "initvalue": true
-          },
-          {
             "label": "Related Entries Source",
             "helpnote": "Select the related entries source.",
             "configObject": "playlistSelectBox",


### PR DESCRIPTION
remove the showOnPlaybackDone checkbox