### PR TITLE
fix(LMS-387): Hide option to upgrade to V7 when V7 is disabled in Partner config.

### DIFF
--- a/app/js/controllers/playerListCtrl.js
+++ b/app/js/controllers/playerListCtrl.js
@@ -3,8 +3,8 @@
 /* Controllers */
 
 angular.module('KMCModule').controller('PlayerListCtrl',
-	['apiService', 'loadINI', '$location', '$rootScope', '$scope', '$filter', '$modal', '$timeout', '$log', "$compile", "$window", 'localStorageService', 'requestNotificationChannel', 'PlayerService', '$q', 'utilsSvc',
-		function (apiService, loadINI, $location, $rootScope, $scope, $filter, $modal, $timeout, $log, $compile, $window, localStorageService, requestNotificationChannel, PlayerService, $q, utilsSvc) {
+	['apiService', 'loadINI', '$location', '$rootScope', '$scope', '$filter', '$modal', '$timeout', '$log', "$compile", "$window", 'localStorageService', 'requestNotificationChannel', 'PlayerService', '$q', 'utilsSvc', 'PermissionsService',
+		function (apiService, loadINI, $location, $rootScope, $scope, $filter, $modal, $timeout, $log, $compile, $window, localStorageService, requestNotificationChannel, PlayerService, $q, utilsSvc, PermissionsService) {
 			// start request to show the spinner. When data is rendered, the onFinishRender directive will hide the spinner
 			requestNotificationChannel.requestStarted('list');
 			$rootScope.lang = 'en-US';
@@ -18,6 +18,21 @@ angular.module('KMCModule').controller('PlayerListCtrl',
 				}
 				return version;
 			};
+
+			$scope.v7UpgradeAllowed = false;
+
+			var checkV7UpgradeAllowed = function () {
+				PermissionsService.hasPermission('FEATURE_V3_STUDIO_PERMISSION')
+					.then(function (result) {
+						$scope.v7UpgradeAllowed = result;
+					}, function (reason) {
+						$log.error('Failed to check permissions: ' + reason);
+						$scope.v7UpgradeAllowed = false;
+					});
+			};
+
+			checkV7UpgradeAllowed();
+
 			// init search
 			$scope.search = '';
 			$scope.searchSelect2Options = {};

--- a/app/js/services/services.js
+++ b/app/js/services/services.js
@@ -623,8 +623,8 @@ KMCServices.factory('PlayerService', ['$http', '$modal', '$log', '$q', 'apiServi
 	}])
 ;
 
-KMCServices.factory('PlayerDataService', ['$http', 'apiService', '$q', '$filter',
-	function ($http, apiService, $q, $filter) {
+KMCServices.factory('PlayerDataService', ['apiService', '$q', '$filter',
+	function (apiService, $q, $filter) {
 		function validateV7Player(player) {
 			return player.tags && player.tags.includes('kalturaPlayerJs');
 		}
@@ -1096,4 +1096,31 @@ KMCServices.factory('playerTemplates', ['$http', function ($http) {
 		}
 	};
 
+}]);
+KMCServices.factory('PermissionsService', ['apiService', '$q', function (apiService, $q) {
+	var permissionsService = {
+		hasPermission: function (permission) {
+			var deferred = $q.defer();
+			apiService.setCache(false);
+			var request = {
+				'service': 'permission',
+				'action': 'getCurrentPermissions'
+			};
+			apiService.doRequest(request).then(function (data) {
+				if (!data) {
+					deferred.resolve(false);
+				} else {
+					var permissions = data.split(',');
+					var hasPermission = permissions.includes(permission);
+					deferred.resolve(hasPermission);
+				}
+			}, function (reason) {
+				deferred.reject(reason);
+			});
+
+			return deferred.promise;
+		}
+	};
+
+	return permissionsService;
 }]);

--- a/app/view/list.html
+++ b/app/view/list.html
@@ -90,6 +90,7 @@
 									translate}}
 								</button>
 								<button type="button" class="btn btn-link"
+										ng-show="v7UpgradeAllowed"
 										ng-click="upgradeV7(item)"><span class="glyphicon glyphicon-arrow-up"></span>
 									{{'Convert to Player V7'|
 									translate}}


### PR DESCRIPTION
### Description of the Changes

When partner is not enable player v7, need to hide the button to upgrade to V7.

Partner config to check:  “Show V3 Studio” => FEATURE_V3_STUDIO_PERMISSION